### PR TITLE
Change to the most recent org.eclipse.jgit-1.3.0.201202151440-r

### DIFF
--- a/jgit-buildnumber-ant-task/pom.xml
+++ b/jgit-buildnumber-ant-task/pom.xml
@@ -16,7 +16,8 @@
         <dependency>
             <groupId>org.eclipse.jgit</groupId>
             <artifactId>org.eclipse.jgit</artifactId>
-            <version>1.1.0.201109151100-r</version>
+            <version>1.3.0.201202151440-r</version>
+            <!--<version>1.1.0.201109151100-r</version>-->
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/maven-jgit-buildnumber-plugin/pom.xml
+++ b/maven-jgit-buildnumber-plugin/pom.xml
@@ -22,7 +22,8 @@
         <dependency>
             <groupId>org.eclipse.jgit</groupId>
             <artifactId>org.eclipse.jgit</artifactId>
-            <version>1.1.0.201109151100-r</version>
+            <version>1.3.0.201202151440-r</version>
+            <!--<version>1.1.0.201109151100-r</version>-->
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
org.eclipse.jgit-1.1.0.201109151100-r is not found on the Maven repos any more. Change to the most recent org.eclipse.jgit-1.3.0.201202151440-r
