### PR TITLE
provide 'build.timestamp' along with other 'git.*' properties

### DIFF
--- a/jgit-buildnumber-ant-task/src/main/java/ru/concerteza/util/buildnumber/BuildTimestampFactory.java
+++ b/jgit-buildnumber-ant-task/src/main/java/ru/concerteza/util/buildnumber/BuildTimestampFactory.java
@@ -1,0 +1,17 @@
+package ru.concerteza.util.buildnumber;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+/**
+ * User: plevart
+ * Date: 3/28/12
+ */
+public class BuildTimestampFactory {
+    public static final String DEFAULT_BUILD_TIMESTAMP_FORMAT = "yyyyMMdd'T'HHmmss";
+
+    public static String createBuildTimestamp(String buildTimestampFormat) {
+        return new SimpleDateFormat(buildTimestampFormat)
+            .format(new Date());
+    }
+}

--- a/jgit-buildnumber-ant-task/src/main/java/ru/concerteza/util/buildnumber/JGitBuildNumberAntTask.java
+++ b/jgit-buildnumber-ant-task/src/main/java/ru/concerteza/util/buildnumber/JGitBuildNumberAntTask.java
@@ -23,5 +23,6 @@ public class JGitBuildNumberAntTask {
         project.setProperty("git.branch", bn.getBranch());
         project.setProperty("git.tag", bn.getTag());
         project.setProperty("git.commitsCount", bn.getCommitsCountAsString());
+        project.setProperty("build.timestamp", BuildTimestampFactory.createBuildTimestamp(BuildTimestampFactory.DEFAULT_BUILD_TIMESTAMP_FORMAT));
     }
 }

--- a/maven-jgit-buildnumber-plugin/src/main/java/ru/concerteza/util/buildnumber/JGitBuildNumberMojo.java
+++ b/maven-jgit-buildnumber-plugin/src/main/java/ru/concerteza/util/buildnumber/JGitBuildNumberMojo.java
@@ -11,7 +11,6 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.project.MavenProject;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.Properties;
 
 /**
@@ -45,6 +44,18 @@ public class JGitBuildNumberMojo extends AbstractMojo {
      * @parameter expression="${commitsCountProperty}"
      */
     private String commitsCountProperty = "git.commitsCount";
+    /**
+     * Build timestamp property name
+     *
+     * @parameter expression="${buildTimestampProperty}"
+     */
+    private String buildTimestampProperty = "build.timestamp";
+    /**
+     * Build timestamp format (SimpleDateFormat pattern)
+     *
+     * @parameter expression="${buildTimestampFormat}"
+     */
+    private String buildTimestampFormat = BuildTimestampFactory.DEFAULT_BUILD_TIMESTAMP_FORMAT;
     /**
      * @parameter expression="${project.basedir}"
      * @required
@@ -87,6 +98,7 @@ public class JGitBuildNumberMojo extends AbstractMojo {
                 props.setProperty(branchProperty, bn.getBranch());
                 props.setProperty(tagProperty, bn.getTag());
                 props.setProperty(commitsCountProperty, bn.getCommitsCountAsString());
+                props.setProperty(buildTimestampProperty, BuildTimestampFactory.createBuildTimestamp(buildTimestampFormat));
             } else if("pom".equals(parentProject.getPackaging())) {
                 // build started from parent, we are in subproject, lets provide parent properties to our project
                 Properties parentProps = parentProject.getProperties();
@@ -94,6 +106,7 @@ public class JGitBuildNumberMojo extends AbstractMojo {
                 props.setProperty(branchProperty, parentProps.getProperty(branchProperty));
                 props.setProperty(tagProperty, parentProps.getProperty(tagProperty));
                 props.setProperty(commitsCountProperty, parentProps.getProperty(commitsCountProperty));
+                props.setProperty(buildTimestampProperty, parentProps.getProperty(buildTimestampProperty));
             } else {
                 // should not happen
                 getLog().warn("Cannot extract JGit version: something wrong with build process, we're not in parent, not in subproject!");
@@ -110,5 +123,6 @@ public class JGitBuildNumberMojo extends AbstractMojo {
         props.setProperty(branchProperty, "UNKNOWN_BRANCH");
         props.setProperty(tagProperty, "UNKNOWN_TAG");
         props.setProperty(commitsCountProperty, "-1");
+        props.setProperty(buildTimestampProperty, "UNKNOWN_BUILD_TIMESTAMP");
     }
 }


### PR DESCRIPTION
Thanks for quick pull of previous change.

When we migrated our project from SVN to Git, we needed a Git capable buildnumber-maven-plugin replacement. Googling around we found this project, which works perfectly with no cross-platform hassles. The only functionality that was missing and is provided by buildnumber-maven-plugin is 'build.timestamp' property, which we use to stamp out build artefacts with. The following is my try at adding this functionality to maven-jgit-buildnumber-plugin...
