### PR TITLE
Added a new Maven plugin configuration parameter named 'runOnlyAtExecuti...

### DIFF
--- a/maven-jgit-buildnumber-plugin/src/main/java/ru/concerteza/util/buildnumber/JGitBuildNumberMojo.java
+++ b/maven-jgit-buildnumber-plugin/src/main/java/ru/concerteza/util/buildnumber/JGitBuildNumberMojo.java
@@ -60,6 +60,10 @@ public class JGitBuildNumberMojo extends AbstractMojo {
      */
     private String javaScriptBuildnumberCallback = null;
     /**
+     * @parameter expression="${runOnlyAtExecutionRoot}" default-value="true"
+     */
+    private boolean runOnlyAtExecutionRoot;
+    /**
      * Directory to start searching git root from, should contain '.git' directory
      * or be a subdirectory of such directory. '${project.basedir}' is used by default.
      *
@@ -106,7 +110,7 @@ public class JGitBuildNumberMojo extends AbstractMojo {
         try {
             // executes only once per build
             // http://www.sonatype.com/people/2009/05/how-to-make-a-plugin-run-once-during-a-build/
-            if (executionRootDirectory.equals(baseDirectory)) {
+            if (executionRootDirectory.equals(baseDirectory) || !runOnlyAtExecutionRoot) {
                 // build started from this projects root
                 BuildNumber bn = BuildNumberExtractor.extract(repositoryDirectory);
                 props.setProperty(revisionProperty, bn.getRevision());


### PR DESCRIPTION
I really appreciate your plugin! I have run into a limitation imposed by your enforcement of single plugin execution in a multi-module reactor.

The problem stems from variances in Maven project layout. The plugin currently is coded to require that the reactor root pom.xml also be the parent pom.xml for all of its modules. This is a common setup, but is not mandatory. Some projects have the shared parent pom.xml as a sub-module, or outside of the project entirely.

I have added a simple enhancement to allow for flexibility when used by projects not adhering to the expected layout and inheritance.

This idea is actually derived from the same post used to create the singular exclusion.
http://www.sonatype.com/people/2009/05/how-to-make-a-plugin-run-once-during-a-build/

I added a new Maven plugin configuration parameter named 'runOnlyAtExecutionRoot' to allow for the plugin to execute in each module of a multi-module reactor, or restrict to running once in a reactor.

The default value is 'true' which maintains the existing behavior of the plugin to run only once in a reactor build.

This change simply allows for this plugin to be used in Maven multi-module projects without error if they do not conform to the expected project layout, at the cost of having the information extracted for each module.
