### PR TITLE
use correct idiom to map to the current directory

### DIFF
--- a/jgit-buildnumber-ant-task/src/main/java/ru/concerteza/util/buildnumber/JGitBuildNumberAntTask.java
+++ b/jgit-buildnumber-ant-task/src/main/java/ru/concerteza/util/buildnumber/JGitBuildNumberAntTask.java
@@ -40,7 +40,7 @@ public class JGitBuildNumberAntTask {
      */
     public void execute() throws IOException {
         String repoDirString = project.getProperty("git.repositoryDirectory");
-        File repoDir = null != repoDirString ? new File(repoDirString) :  new File("");
+        File repoDir = null != repoDirString ? new File(repoDirString) :  new File(".");
         BuildNumber bn = BuildNumberExtractor.extract(repoDir);
         project.setProperty("git.revision", bn.getRevision());
         project.setProperty("git.shortRevision", bn.getShortRevision());


### PR DESCRIPTION
The instance created by new File("") fails both the exists() and
isDirectory() tests even though both getAbsolutePath() and
getCanonicalPath() will return the current directory.

The task is expected to default to the current working directory when
git.repositoryDirectory is not set.

If new File("") is used instead of new File(".") to create an instance
of File defaulting to the current directory, the instance fails both the
exists() and isDirectory() tests even though both getAbsolutePath() and
getCanonicalPath() will return the current directory.

The build number extractor fails, because exists() and isDirectory()
both return false. The detail message in the instance of IOException
that it creates uses getCanonicalPath() (which returns the current
directory). This results in a confusing error message that leads the
user to conclude that the current working directory is not a valid git
working directory despite being one.
