### PR TITLE
Added Gradle plugin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Git buildnumber plugin for Maven and Ant based on JGit
+Git buildnumber plugin for Maven, Gradle and Ant based on JGit
 ======================================================
 
 Allows to get git buildnumbers, while building java projects, in pure Java without Git command-line tool.
@@ -189,6 +189,83 @@ If you want to customize it, you can use Ant [Script task](http://ant.apache.org
             project.setProperty("git.buildnumber", buildnumber)
         </script>
     </target>
+
+Usage in Gradle
+----------------
+
+ - Add the plugin dependency in your build.gradle `classpath 'ru.concerteza.buildnumber:gradle-jgit-buildnumber-plugin:1.2.9-SNAPSHOT'`
+ - Apply the plugin in one of the following ways `apply plugin: 'gradle-jgit-buildnumber-plugin'` or `apply plugin: ru.concerteza.util.buildnumber.plugin.JGitBuildNumberPlugin`
+ - Execute the jGitBuildnumber_ExtractBuildnumber task `tasks.jGitBuildnumber_ExtractBuildnumber.execute()`
+ 
+ Extracted properties are put into:
+ 
+  - `project.gitTag`
+  - `project.gitBranch`
+  - `project.gitRevision`
+  - `project.gitBuildnumber`
+  - `project.gitCommitsCount`
+  - `project.gitParent`
+  
+  Example setup in build.gradle:
+
+    ```
+    buildscript {
+      repositories{  
+         mavenLocal()  
+      }  
+      dependencies {  
+         classpath 'ru.concerteza.buildnumber:gradle-jgit-buildnumber-plugin:1.2.9-SNAPSHOT'  
+      }  
+    }  
+    apply plugin: 'gradle-jgit-buildnumber-plugin'  
+    ```
+    
+  The default working directory in the plugin is "." i.e this directory, if you wish to set a custom directory then the following should be added to your build.gradle
+   
+    ```
+    task jGitBuildnumber_ExtractBuildnumber() {
+       dir = projectDir;
+    }
+    ```
+        
+  projectDir is just an example.
+    
+  Example usage:
+  
+    ```
+    jar() {
+        manifest {
+            attributes(
+                    'Main-Class': mainClassName,
+                    'Implementation-Title': project.name,
+                    'Implementation-Version': project.gitRevision,
+                    'Specification-Version': project.gitCommitsCount,
+                    'X-Git-Branch': project.gitBranch,
+                    'X-Git-Tag': project.gitTag,
+                    'Version' : project.gitCommitsCount,
+                    'Branch' : project.gitBranch
+            )
+        }
+    }  
+    ```
+    
+  Results example (from MANIFEST.MF):
+    ```
+    Manifest-Version: 1.0
+    Main-Class: SearchService.application.SearchServiceMain
+    Implementation-Title: SearchService
+    Implementation-Vendor: 
+    Implementation-Version: 3b03c4d3531c66648c4fe7fcd7f53b3e9f64e519
+    Specification-Version: 82
+    X-Git-Branch: master
+    X-Git-Tag: 
+    Version: 82
+    Branch: master
+    ```
+    
+###Ready to use buildnumber
+  
+  Default buildnumber in form `<tag or branch>.<commitsCount>.<shortRevision>` will be put into property `project.gitBuildnumber`.
 
 Common errors
 -------------

--- a/gradle-jgit-buildnumber-plugin/pom.xml
+++ b/gradle-jgit-buildnumber-plugin/pom.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>jgit-buildnumber-parent</artifactId>
+        <groupId>ru.concerteza.buildnumber</groupId>
+        <version>1.2.9-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>gradle-jgit-buildnumber-plugin</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jgit-buildnumber-ant-task</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-all</artifactId>
+            <version>2.3.7</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jgit</groupId>
+            <artifactId>org.eclipse.jgit</artifactId>
+            <version>2.0.0.201206130900-r</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <version>3.0.3</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.gradle</groupId>
+            <artifactId>gradle-core</artifactId>
+            <version>2.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.gradle</groupId>
+            <artifactId>gradle-base-services</artifactId>
+            <version>2.1</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.gradle</groupId>
+            <artifactId>gradle-base-services-groovy</artifactId>
+            <version>2.1</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.9.5</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.1</version>
+                <configuration>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>1.3.1</version>
+                <executions>
+                    <execution>
+                        <id>enforce</id>
+                        <configuration>
+                            <rules>
+                                <requireUpperBoundDeps>
+                                    <!-- 'uniqueVersions' (default:false) can be set to true if you want to compare the timestamped SNAPSHOTs  -->
+                                    <!-- <uniqueVersions>true</uniqueVersions> -->
+                                </requireUpperBoundDeps>
+                            </rules>
+                        </configuration>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/gradle-jgit-buildnumber-plugin/src/main/java/ru/concerteza/util/buildnumber/plugin/JGitBuildNumberPlugin.java
+++ b/gradle-jgit-buildnumber-plugin/src/main/java/ru/concerteza/util/buildnumber/plugin/JGitBuildNumberPlugin.java
@@ -1,0 +1,12 @@
+package ru.concerteza.util.buildnumber.plugin;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import ru.concerteza.util.buildnumber.task.*;
+
+public class JGitBuildNumberPlugin implements Plugin<Project> {
+
+    public void apply(Project target) {
+        target.getTasks().replace("jGitBuildnumber_ExtractBuildnumber", JGitBuildNumberExtractBuildnumber.class);
+    }
+}

--- a/gradle-jgit-buildnumber-plugin/src/main/java/ru/concerteza/util/buildnumber/task/JGitBuildNumberExtractBuildnumber.java
+++ b/gradle-jgit-buildnumber-plugin/src/main/java/ru/concerteza/util/buildnumber/task/JGitBuildNumberExtractBuildnumber.java
@@ -1,0 +1,27 @@
+package ru.concerteza.util.buildnumber.task;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.tasks.TaskAction;
+import ru.concerteza.util.buildnumber.BuildNumber;
+import ru.concerteza.util.buildnumber.BuildNumberExtractor;
+import ru.concerteza.util.buildnumber.utils.GitBuildInformation;
+
+import java.io.File;
+import java.io.IOException;
+
+public class JGitBuildNumberExtractBuildnumber extends DefaultTask {
+
+    String dir = ".";
+
+    @TaskAction
+    public void jGitBuildnumber_ExtractBuildnumber() throws IOException {
+        BuildNumber buildNumber = BuildNumberExtractor.extract(new File(dir));
+        final GitBuildInformation gitBuildInformation = new GitBuildInformation(buildNumber);
+        this.getProject().getExtensions().getExtraProperties().set("gitBranch", gitBuildInformation.getBranch());
+        this.getProject().getExtensions().getExtraProperties().set("gitCommitsCount", gitBuildInformation.getCommitsCountAsString());
+        this.getProject().getExtensions().getExtraProperties().set("gitTag", gitBuildInformation.getTag());
+        this.getProject().getExtensions().getExtraProperties().set("gitRevision", gitBuildInformation.getRevision());
+        this.getProject().getExtensions().getExtraProperties().set("gitParent", gitBuildInformation.getParent());
+        this.getProject().getExtensions().getExtraProperties().set("gitBuildnumber", gitBuildInformation.getDefaultBuildNumber());
+    }
+}

--- a/gradle-jgit-buildnumber-plugin/src/main/java/ru/concerteza/util/buildnumber/utils/GitBuildInformation.java
+++ b/gradle-jgit-buildnumber-plugin/src/main/java/ru/concerteza/util/buildnumber/utils/GitBuildInformation.java
@@ -1,0 +1,44 @@
+package ru.concerteza.util.buildnumber.utils;
+
+import ru.concerteza.util.buildnumber.BuildNumber;
+import ru.concerteza.util.buildnumber.BuildNumberExtractor;
+
+import java.io.File;
+import java.io.IOException;
+
+public class GitBuildInformation {
+
+    private BuildNumber buildNumber;
+
+    public GitBuildInformation(BuildNumber buildNumber) {
+        this.buildNumber = buildNumber;
+    }
+
+    public String getCommitsCountAsString() throws IOException {
+        return buildNumber.getCommitsCountAsString();
+    }
+
+    public String getBranch() {
+        return buildNumber.getBranch();
+    }
+
+    public String getParent() {
+        return buildNumber.getParent();
+    }
+
+    public String getRevision() {
+        return buildNumber.getRevision();
+    }
+
+    public String getShortRevision() {
+        return buildNumber.getShortRevision();
+    }
+
+    public String getTag() {
+        return buildNumber.getTag();
+    }
+
+    public String getDefaultBuildNumber() throws IOException {
+        return buildNumber.defaultBuildnumber();
+    }
+}

--- a/gradle-jgit-buildnumber-plugin/src/main/resources/META-INF/gradle-plugins/gradle-jgit-buildnumber-plugin.properties
+++ b/gradle-jgit-buildnumber-plugin/src/main/resources/META-INF/gradle-plugins/gradle-jgit-buildnumber-plugin.properties
@@ -1,0 +1,1 @@
+implementation-class=ru.concerteza.util.buildnumber.plugin.JGitBuildNumberPlugin

--- a/gradle-jgit-buildnumber-plugin/src/test/java/ru/concerteza/util/buildnumber/task/GitBuildInformationTest.java
+++ b/gradle-jgit-buildnumber-plugin/src/test/java/ru/concerteza/util/buildnumber/task/GitBuildInformationTest.java
@@ -1,0 +1,73 @@
+package ru.concerteza.util.buildnumber.task;
+
+import org.junit.Before;
+import org.junit.Test;
+import ru.concerteza.util.buildnumber.BuildNumber;
+import ru.concerteza.util.buildnumber.utils.GitBuildInformation;
+
+import java.io.IOException;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class GitBuildInformationTest {
+
+    private GitBuildInformation gitBuildInformation;
+
+    @Before
+    public void beforeEachTest() throws IOException {
+        BuildNumber buildNumber = new BuildNumber("1234567890", "branch", "tag", "parent", 37);
+        gitBuildInformation = new GitBuildInformation(buildNumber);
+    }
+
+    @Test
+    public void returnsCorrectNumberOfGitCommitsCount() throws IOException {
+        assertThat(gitBuildInformation.getCommitsCountAsString(), is("37"));
+    }
+
+    @Test
+    public void returnsCorrectBranch() throws IOException {
+        assertThat(gitBuildInformation.getBranch(), is("branch"));
+    }
+
+    @Test
+    public void returnsCorrectParent() throws IOException {
+        assertThat(gitBuildInformation.getParent(), is("parent"));
+    }
+
+    @Test
+    public void returnsCorrectRevision() throws IOException {
+        assertThat(gitBuildInformation.getRevision(), is("1234567890"));
+    }
+
+    @Test
+    public void returnsCorrectTag() throws IOException {
+        assertThat(gitBuildInformation.getTag(), is("tag"));
+    }
+
+    @Test
+    public void returnsShortRevision() throws IOException {
+        assertThat(gitBuildInformation.getShortRevision(), is("1234567"));
+    }
+
+    @Test
+    public void returnsCorrectDefaultBuildNumber() throws IOException {
+        assertThat(gitBuildInformation.getDefaultBuildNumber(), is("tag.37.1234567"));
+    }
+
+    @Test
+    public void setsBranchAsNameIfTagIsNotPresent() throws IOException {
+        BuildNumber buildNumber = new BuildNumber("1234567890", "branch", "", "parent", 37);
+        gitBuildInformation = new GitBuildInformation(buildNumber);
+
+        assertThat(gitBuildInformation.getDefaultBuildNumber(), is("branch.37.1234567"));
+    }
+
+    @Test
+    public void setsUNNAMEDAsNameIdTagAndBranchAreNotPresent() throws IOException {
+        BuildNumber buildNumber = new BuildNumber("1234567890", "", "", "parent", 37);
+        gitBuildInformation = new GitBuildInformation(buildNumber);
+
+        assertThat(gitBuildInformation.getDefaultBuildNumber(), is("UNNAMED.37.1234567"));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
     <modules>
         <module>maven-jgit-buildnumber-plugin</module>
         <module>jgit-buildnumber-ant-task</module>
+        <module>gradle-jgit-buildnumber-plugin</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
We have added a new Maven module which is a Gradle plugin with very similar functionality to the Maven plugin that already existed. We also added the module to the parent pom and added instructions on how to use the Gradle plugin in the readme file.

We have not worried about the JavaScript execution as the Gradle build file support Groovy which gives us the functionality to build our own custom build number.

Is there anything we need to do to get this published to the Maven Repo?
